### PR TITLE
fix: make branch protection work

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ReposUpdateBranchProtectionParamsRequiredStatusChecks} from '@octokit/rest';
+
 export interface IssueResult {
   issues: Issue[];
   repo: Repo;
@@ -148,4 +150,16 @@ export interface Organization {
 export interface Flags {
   // tslint:disable-next-line no-any
   [index: string]: any;
+}
+
+export interface GetBranchProtectionResult {
+  enabled: boolean;
+  required_status_checks: ReposUpdateBranchProtectionParamsRequiredStatusChecks;
+}
+
+export interface GetBranchResult {
+  name: string;
+
+  protected: boolean;
+  protection?: GetBranchProtectionResult;
 }


### PR DESCRIPTION
Replacing a bunch of commented lines with (hopefully) working lines.

1. Check if the repo has required status checks, and remember them (otherwise they will be reset).
2. Apply master branch protection:
- pull request reviews required
- enforcement for admins
- status checks as stored on step 1.

I have never tested it :)  but my similar [script](https://gist.github.com/alexander-fenster/06324d52a42580ff8f82b3bd88e22a76) works so I'm at least sure about call parameters I use.