### PR TITLE
Add Amanda Tarafa Mas and Mike Dour to Yoshi lists for .NET

### DIFF
--- a/users.json
+++ b/users.json
@@ -50,7 +50,9 @@
         "dhermes",
         "dpebot",
         "jmdobry",
-        "becca"
+        "becca",
+        "amanda-tarafa",
+        "evildour"
       ],
       "repos": [
         "googleapis/discovery-artifact-manager",
@@ -147,7 +149,9 @@
       "users": [
         "justinbeckwith",
         "jskeet",
-        "chrisdunelm"
+        "chrisdunelm",
+        "amanda-tarafa",
+        "evildour"
       ],
       "repos": [
         "google/google-api-dotnet-client",


### PR DESCRIPTION
(Amanda is a permanent team member; Mike was 20% and is mostly rolling off, but is likely to still have occasional contributions around Bigtable.)